### PR TITLE
Changed GrokWebsphereParser to extend GrokParser

### DIFF
--- a/metron-platform/metron-parsers/src/main/flux/websphere/remote.yaml
+++ b/metron-platform/metron-parsers/src/main/flux/websphere/remote.yaml
@@ -22,8 +22,15 @@ components:
     -   id: "parser"
         className: "org.apache.metron.parsers.websphere.GrokWebSphereParser"
         constructorArgs:
-            - "/apps/metron/patterns/websphere"
+            - "/patterns/websphere"
             - "WEBSPHERE"
+        configMethods:
+            -   name: "withTimestampField"
+                args:
+                    - "timestamp_string"
+            -   name: "withDateFormat"
+                args:
+                    - "yyyy MMM dd HH:mm:ss"
     -   id: "writer"
         className: "org.apache.metron.parsers.writer.KafkaWriter"
         constructorArgs:

--- a/metron-platform/metron-parsers/src/main/flux/websphere/test.yaml
+++ b/metron-platform/metron-parsers/src/main/flux/websphere/test.yaml
@@ -24,6 +24,13 @@ components:
         constructorArgs:
             - "../metron-parsers/src/main/resources/patterns/websphere"
             - "WEBSPHERE"
+        configMethods:
+            -   name: "withTimestampField"
+                args:
+                    - "timestamp_string"
+            -   name: "withDateFormat"
+                args:
+                    - "yyyy MMM dd HH:mm:ss"
     -   id: "writer"
         className: "org.apache.metron.parsers.writer.KafkaWriter"
         constructorArgs:

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/GrokParser.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/GrokParser.java
@@ -50,13 +50,13 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
   protected String patternLabel;
   protected String[] timeFields = new String[0];
   protected String timestampField;
-  protected String dateFormat = "yyyy-MM-dd HH:mm:ss.S z";
+  protected SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S z");
   protected TimeZone timeZone = TimeZone.getTimeZone("UTC");
   protected String patternsCommonDir = "/patterns/common";
 
-  public GrokParser(String grokHdfsPath, String patterLabel) {
+  public GrokParser(String grokHdfsPath, String patternLabel) {
     this.grokHdfsPath = grokHdfsPath;
-    this.patternLabel = patterLabel;
+    this.patternLabel = patternLabel;
   }
 
   public GrokParser withTimestampField(String timestampField) {
@@ -76,7 +76,7 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
   }
 
   public GrokParser withDateFormat(String dateFormat) {
-    this.dateFormat = dateFormat;
+    this.dateFormat = new SimpleDateFormat(dateFormat);
     if (LOG.isDebugEnabled()) {
       LOG.debug("Grok parser settting date format: " + dateFormat);
     }
@@ -179,6 +179,7 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
         message.put(Constants.Fields.TIMESTAMP.getName(), formatTimestamp(message.get(timestampField)));
       }
       message.remove(patternLabel);
+      postParse(message);
       messages.add(message);
       if (LOG.isDebugEnabled()) {
         LOG.debug("Grok parser parsed message: " + message);
@@ -213,17 +214,18 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
     return false;
   }
 
-  private long toEpoch(String datetime) throws ParseException {
+  protected void postParse(JSONObject message) {}
+
+  protected long toEpoch(String datetime) throws ParseException {
 
     if (LOG.isDebugEnabled()) {
       LOG.debug("Grok perser converting timestamp to epoch: " + datetime);
     }
 
-    SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
-    sdf.setTimeZone(timeZone);
-    Date date = sdf.parse(datetime);
+    dateFormat.setTimeZone(timeZone);
+    Date date = dateFormat.parse(datetime);
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Grok perser converted timestamp to epoch: " + sdf.parse(datetime));
+      LOG.debug("Grok perser converted timestamp to epoch: " + date);
     }
 
     return date.getTime();
@@ -232,7 +234,7 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
   protected long formatTimestamp(Object value) {
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Grok perser formatting timestamp" + value);
+      LOG.debug("Grok parser formatting timestamp" + value);
     }
 
 

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/websphere/GrokWebSphereParserTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/websphere/GrokWebSphereParserTest.java
@@ -24,12 +24,18 @@ import org.json.simple.JSONObject;
 import org.junit.Test;
 
 public class GrokWebSphereParserTest {
+
+	private final String grokPath = "../metron-parsers/src/main/resources/patterns/websphere";
+	private final String grokLabel = "WEBSPHERE";
+	private final String dateFormat = "yyyy MMM dd HH:mm:ss";
+	private final String timestampField = "timestamp_string";
 	
 	@Test
 	public void testParseLoginLine() throws Exception {
 		
 		//Set up parser, parse message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
+		GrokWebSphereParser parser = new GrokWebSphereParser(grokPath, grokLabel);
+		parser.withDateFormat(dateFormat).withTimestampField(timestampField);
 		String testString = "<133>Apr 15 17:47:28 ABCXML1413 [rojOut][0x81000033][auth][notice] user(rick007): "
 				+ "[120.43.200.6]: User logged into 'cohlOut'.";
 		List<JSONObject> result = parser.parse(testString.getBytes());
@@ -52,7 +58,8 @@ public class GrokWebSphereParserTest {
 	public void tetsParseLogoutLine() throws Exception {
 		
 		//Set up parser, parse message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
+		GrokWebSphereParser parser = new GrokWebSphereParser(grokPath, grokLabel);
+		parser.withDateFormat(dateFormat).withTimestampField(timestampField);
 		String testString = "<134>Apr 15 18:02:27 PHIXML3RWD [0x81000019][auth][info] [14.122.2.201]: "
 				+ "User 'hjpotter' logged out from 'default'.";
 		List<JSONObject> result = parser.parse(testString.getBytes());
@@ -74,7 +81,8 @@ public class GrokWebSphereParserTest {
 	public void tetsParseRBMLine() throws Exception {
 		
 		//Set up parser, parse message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
+		GrokWebSphereParser parser = new GrokWebSphereParser(grokPath, grokLabel);
+		parser.withDateFormat(dateFormat).withTimestampField(timestampField);
 		String testString = "<131>Apr 15 17:36:35 ROBXML3QRS [0x80800018][auth][error] rbm(RBM-Settings): "
 				+ "trans(3502888135)[request] gtid(3502888135): RBM: Resource access denied.";
 		List<JSONObject> result = parser.parse(testString.getBytes());
@@ -95,7 +103,8 @@ public class GrokWebSphereParserTest {
 	public void tetsParseOtherLine() throws Exception {
 		
 		//Set up parser, parse message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
+		GrokWebSphereParser parser = new GrokWebSphereParser(grokPath, grokLabel);
+		parser.withDateFormat(dateFormat).withTimestampField(timestampField);
 		String testString = "<134>Apr 15 17:17:34 SAGPXMLQA333 [0x8240001c][audit][info] trans(191): (admin:default:system:*): "
 				+ "ntp-service 'NTP Service' - Operational state down";
 		List<JSONObject> result = parser.parse(testString.getBytes());


### PR DESCRIPTION
Hey @DomenicPuzio, here's a quick example I came up with to extend the GrokParser.  Basically I added a "postParse(JSONObject message)" method that can be overridden to further process a message.  All of the grok functionality stays in GrokParser.  Let me know what you think.